### PR TITLE
Add Q21567758 to be scraped as an extra

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -78,7 +78,7 @@ data[:replace2014] = EveryPolitician::Wikidata.wikipedia_xpath(
   xpath: '//table[.//th[.="Ny ledamot"]]//tr[td]//td[position() = last()]//a[not(@class="new")][1]/@title',
 )
 
-extras = %w(Q5950878 Q4952392 Q4949319 Q4967713 Q6255733)
+extras = %w(Q5950878 Q4952392 Q4949319 Q4967713 Q6255733 Q21567758)
 
 EveryPolitician::Wikidata.scrape_wikidata(ids: extras, names: { sv: data.values.flatten.uniq })
 


### PR DESCRIPTION
A member has a wikidata entry but does not have a wikipedia page. Therefore we need to hardcode the wikidata ID into the scraper.

Part of: https://github.com/everypolitician/everypolitician-data/issues/25278